### PR TITLE
ci(rust): publish rust package into crates.io

### DIFF
--- a/.github/workflows/publich_rust.yml
+++ b/.github/workflows/publich_rust.yml
@@ -1,0 +1,35 @@
+name: Publish to Crates.io
+
+on:
+    push:
+        branches:
+            - main
+
+    pull_request:
+        branches:
+            - main
+
+# Trigger the workflow only on version tags (e.g., v1.0.0)
+# on:
+#   push:
+#     tags:
+#       - "v*"
+
+jobs:
+  publish:
+    name: Publish Rust crate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Dry-run publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cd rust
+          cargo publish --dry-run --all-features --verbose

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,5 +3,5 @@
 version = 4
 
 [[package]]
-name = "project-name"
+name = "rust-boilerplate"
 version = "1.0.0"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "project-name"
+name = "rust-boilerplate"
 version = "1.0.0"
 authors = ["ezeX development team"]
 edition = "2024"


### PR DESCRIPTION
## Description

Published rust package in https://crates.io/ in dry-run mode.
