### PR TITLE
chore(go): update linters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -45,3 +45,7 @@ tab_width = 2
 end_of_line = lf
 quote_type = double
 max_line_length = 80
+
+[*.py]
+indent_style = space
+indent_size = 4

--- a/go/.golangci.yml
+++ b/go/.golangci.yml
@@ -63,7 +63,7 @@ linters:
     - stylecheck
     - tagalign
     - tagliatelle
-    - tenv
+    - usetesting
     - testableexamples
     - thelper
     - tparallel
@@ -222,7 +222,7 @@ issues:
         - forbidigo
 
   exclude:
-    - "shadow: declaration of \"err\" shadows"
-    - "builtinShadow: shadowing of predeclared identifier: min"
-    - "builtinShadow: shadowing of predeclared identifier: max"
-    - "builtinShadow: shadowing of predeclared identifier: len"
+    - 'shadow: declaration of "err" shadows'
+    - 'builtinShadow: shadowing of predeclared identifier: min'
+    - 'builtinShadow: shadowing of predeclared identifier: max'
+    - 'builtinShadow: shadowing of predeclared identifier: len'


### PR DESCRIPTION
## Description

This PR replace `tenv` with `usetesting` linter that is deprecated.
