### PR TITLE
chore: add ireturn linter

### DIFF
--- a/go/.gitignore
+++ b/go/.gitignore
@@ -14,3 +14,5 @@ todo
 # VIM artifacts
 .swp
 .*.sw*
+
+.env

--- a/go/.golangci.yml
+++ b/go/.golangci.yml
@@ -72,9 +72,9 @@ linters:
     - usestdlibvars
     - wastedassign
     - whitespace
-    - wrapcheck
     - zerologlint
     - varnamelen
+    - ireturn
 
 linters-settings:
   gosimple:

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -29,3 +29,5 @@ todo
 # VIM artifacts
 .swp
 .*.sw*
+
+.env

--- a/ts/.gitignore
+++ b/ts/.gitignore
@@ -22,3 +22,5 @@ todo
 
 # You can keep yarn.lock to ensure dependency consistency
 # yarn.lock
+
+.env


### PR DESCRIPTION
## Description

This PR:

1. Add [ireturn](https://golangci-lint.run/usage/linters/#ireturn) 
2. Remove [wrapcheck](https://golangci-lint.run/usage/linters/#wrapcheck) as it is not really practical in development (Reviewer: Please comment here)